### PR TITLE
registryFix

### DIFF
--- a/set_custom_shell.ps1
+++ b/set_custom_shell.ps1
@@ -61,14 +61,29 @@ else {
 
 # Ensure each parent key exists for the Winlogon key
 $parentPath = "Registry::HKEY_USERS\$userSID\Software\Microsoft\Windows NT\CurrentVersion"
+Write-Host "[DEBUG] Checking parent path: $parentPath" -ForegroundColor Cyan
 if (-not (Test-Path $parentPath)) {
-    New-Item -Path "Registry::HKEY_USERS\$userSID\Software\Microsoft\Windows NT" -Name 'CurrentVersion' -Force | Out-Null
+    Write-Host "[DEBUG] Creating parent key: Registry::HKEY_USERS\$userSID\Software\Microsoft\Windows NT Name='CurrentVersion'" -ForegroundColor Cyan
+    try {
+        New-Item -Path "Registry::HKEY_USERS\$userSID\Software\Microsoft\Windows NT" -Name 'CurrentVersion' -Force | Out-Null
+        Write-Host '[DEBUG] Created parent key successfully.' -ForegroundColor Green
+    }
+    catch {
+        Write-Host "[DEBUG] Failed to create parent key: $_" -ForegroundColor Red
+    }
 }
+Write-Host "[DEBUG] Checking regPath: $regPath" -ForegroundColor Cyan
 if (-not (Test-Path $regPath)) {
-    New-Item -Path $parentPath -Name 'Winlogon' -Force | Out-Null
+    Write-Host "[DEBUG] Creating Winlogon key: $regPath" -ForegroundColor Cyan
+    try {
+        New-Item -Path $parentPath -Name 'Winlogon' -Force | Out-Null
+        Write-Host '[DEBUG] Created Winlogon key successfully.' -ForegroundColor Green
+    }
+    catch {
+        Write-Host "[DEBUG] Failed to create Winlogon key: $_" -ForegroundColor Red
+    }
 }
-
-# Double-check the key exists before setting the property
+Write-Host "[DEBUG] Verifying Winlogon key exists: $regPath" -ForegroundColor Cyan
 if (-not (Test-Path $regPath)) {
     Write-Host "Failed to create Winlogon registry key for $Username." -ForegroundColor Red
     if ($hiveLoaded) {
@@ -78,8 +93,10 @@ if (-not (Test-Path $regPath)) {
     exit 1
 }
 
+Write-Host "[DEBUG] Attempting to set Shell property at $regPath to $shellValue" -ForegroundColor Cyan
 try {
     Set-ItemProperty -Path $regPath -Name 'Shell' -Value $shellValue -Force
+    Write-Host '[DEBUG] Shell property set successfully.' -ForegroundColor Green
     if ($Restore) {
         Write-Host "Default shell restored to explorer.exe for $Username." -ForegroundColor Green
     }
@@ -89,15 +106,6 @@ try {
 }
 catch {
     Write-Host "Failed to set shell for $Username. Try running as Administrator." -ForegroundColor Red
+    Write-Host "[DEBUG] Set-ItemProperty error: $_" -ForegroundColor Red
 }
-
-# Unload the hive if we loaded it
-if ($hiveLoaded) {
-    try {
-        reg unload HKU\$userSID | Out-Null
-        Write-Host "Unloaded registry hive for $Username." -ForegroundColor Yellow
-    }
-    catch {
-        Write-Host "Failed to unload registry hive for $Username. You may need to unload it manually." -ForegroundColor Red
-    }
 }

--- a/set_custom_shell.ps1
+++ b/set_custom_shell.ps1
@@ -93,10 +93,14 @@ if (-not (Test-Path $regPath)) {
     exit 1
 }
 
-Write-Host "[DEBUG] Attempting to set Shell property at $regPath to $shellValue" -ForegroundColor Cyan
-try {
-    Set-ItemProperty -Path $regPath -Name 'Shell' -Value $shellValue -Force
-    Write-Host '[DEBUG] Shell property set successfully.' -ForegroundColor Green
+Write-Host '[DEBUG] Attempting to set Shell property using reg.exe' -ForegroundColor Cyan
+$regKey = "HKU\$userSID\Software\Microsoft\Windows NT\CurrentVersion\Winlogon"
+$regCmd = "reg add `"$regKey`" /v Shell /t REG_SZ /d `"$shellValue`" /f"
+Write-Host "[DEBUG] Running: $regCmd" -ForegroundColor Cyan
+$regResult = cmd.exe /c $regCmd
+Write-Host $regResult
+if ($LASTEXITCODE -eq 0) {
+    Write-Host '[DEBUG] Shell property set successfully using reg.exe.' -ForegroundColor Green
     if ($Restore) {
         Write-Host "Default shell restored to explorer.exe for $Username." -ForegroundColor Green
     }
@@ -104,7 +108,6 @@ try {
         Write-Host "Custom shell set to $shellValue for $Username. Restart the computer to apply changes." -ForegroundColor Green
     }
 }
-catch {
-    Write-Host "Failed to set shell for $Username. Try running as Administrator." -ForegroundColor Red
-    Write-Host "[DEBUG] Set-ItemProperty error: $_" -ForegroundColor Red
+else {
+    Write-Host "Failed to set shell for $Username using reg.exe." -ForegroundColor Red
 }

--- a/set_custom_shell.ps1
+++ b/set_custom_shell.ps1
@@ -1,113 +1,22 @@
-# This script sets your custom shell (Menu.exe) as the default Windows shell for a specific user.
-# It also provides an option to restore the default shell (explorer.exe).
-# Run this script as Administrator.
-
 param(
-    [string]$Username,
     [switch]$Restore
 )
 
-function Get-UserSID {
-    param([string]$UserName)
-    $objUser = New-Object System.Security.Principal.NTAccount($UserName)
-    try {
-        $strSID = $objUser.Translate([System.Security.Principal.SecurityIdentifier])
-        return $strSID.Value
-    }
-    catch {
-        Write-Host "Could not resolve SID for user $UserName" -ForegroundColor Red
-        exit 1
-    }
-}
+# Set the shell value
+$shellValue = if ($Restore) { 'explorer.exe' } else { "$env:USERPROFILE\\Documents\\Scripts\\Kiosk\\Menu.exe" }
+$regPath = 'HKCU:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon'
 
-if (-not $Username) {
-    Write-Host 'Please provide a username using -Username parameter.' -ForegroundColor Yellow
-    exit 1
-}
-
-$userSID = Get-UserSID -UserName $Username
-$regPath = "Registry::HKEY_USERS\\$userSID\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon"
-# Get user profile path for dynamic shell path
-$userProfile = (Get-CimInstance -ClassName Win32_UserProfile | Where-Object { $_.SID -eq $userSID }).LocalPath
-if (-not $userProfile) {
-    Write-Host "Could not find profile path for $Username (SID: $userSID)." -ForegroundColor Red
-    exit 1
-}
-$shellValue = if ($Restore) { 'explorer.exe' } else { "$userProfile\\Documents\\Scripts\\Kiosk\\Menu.exe" }
-
-# Check if the user's hive is loaded
+# Ensure the Winlogon key exists
 if (-not (Test-Path $regPath)) {
-    # Try to load the user's hive
-    $ntuserDat = Join-Path $userProfile 'NTUSER.DAT'
-    if (-not (Test-Path $ntuserDat)) {
-        Write-Host "NTUSER.DAT not found at $ntuserDat. User profile may not exist or is not loaded." -ForegroundColor Red
-        exit 1
-    }
-    try {
-        reg load HKU\$userSID "$ntuserDat" | Out-Null
-        $hiveLoaded = $true
-        Write-Host "Loaded registry hive for $Username." -ForegroundColor Yellow
-    }
-    catch {
-        Write-Host "Failed to load registry hive for $Username." -ForegroundColor Red
-        exit 1
-    }
+    New-Item -Path $regPath -Force | Out-Null
+}
+
+# Set the Shell property
+Set-ItemProperty -Path $regPath -Name 'Shell' -Value $shellValue -Force
+
+if ($Restore) {
+    Write-Host "Default shell restored to explorer.exe for $env:USERNAME." -ForegroundColor Green
 }
 else {
-    $hiveLoaded = $false
-}
-
-
-
-# Ensure each parent key exists for the Winlogon key
-$parentPath = "Registry::HKEY_USERS\$userSID\Software\Microsoft\Windows NT\CurrentVersion"
-Write-Host "[DEBUG] Checking parent path: $parentPath" -ForegroundColor Cyan
-if (-not (Test-Path $parentPath)) {
-    Write-Host "[DEBUG] Creating parent key: Registry::HKEY_USERS\$userSID\Software\Microsoft\Windows NT Name='CurrentVersion'" -ForegroundColor Cyan
-    try {
-        New-Item -Path "Registry::HKEY_USERS\$userSID\Software\Microsoft\Windows NT" -Name 'CurrentVersion' -Force | Out-Null
-        Write-Host '[DEBUG] Created parent key successfully.' -ForegroundColor Green
-    }
-    catch {
-        Write-Host "[DEBUG] Failed to create parent key: $_" -ForegroundColor Red
-    }
-}
-Write-Host "[DEBUG] Checking regPath: $regPath" -ForegroundColor Cyan
-if (-not (Test-Path $regPath)) {
-    Write-Host "[DEBUG] Creating Winlogon key: $regPath" -ForegroundColor Cyan
-    try {
-        New-Item -Path $parentPath -Name 'Winlogon' -Force | Out-Null
-        Write-Host '[DEBUG] Created Winlogon key successfully.' -ForegroundColor Green
-    }
-    catch {
-        Write-Host "[DEBUG] Failed to create Winlogon key: $_" -ForegroundColor Red
-    }
-}
-Write-Host "[DEBUG] Verifying Winlogon key exists: $regPath" -ForegroundColor Cyan
-if (-not (Test-Path $regPath)) {
-    Write-Host "Failed to create Winlogon registry key for $Username." -ForegroundColor Red
-    if ($hiveLoaded) {
-        reg unload HKU\$userSID | Out-Null
-        Write-Host "Unloaded registry hive for $Username." -ForegroundColor Yellow
-    }
-    exit 1
-}
-
-Write-Host '[DEBUG] Attempting to set Shell property using reg.exe' -ForegroundColor Cyan
-$regKey = "HKU\$userSID\Software\Microsoft\Windows NT\CurrentVersion\Winlogon"
-$regCmd = "reg add `"$regKey`" /v Shell /t REG_SZ /d `"$shellValue`" /f"
-Write-Host "[DEBUG] Running: $regCmd" -ForegroundColor Cyan
-$regResult = cmd.exe /c $regCmd
-Write-Host $regResult
-if ($LASTEXITCODE -eq 0) {
-    Write-Host '[DEBUG] Shell property set successfully using reg.exe.' -ForegroundColor Green
-    if ($Restore) {
-        Write-Host "Default shell restored to explorer.exe for $Username." -ForegroundColor Green
-    }
-    else {
-        Write-Host "Custom shell set to $shellValue for $Username. Restart the computer to apply changes." -ForegroundColor Green
-    }
-}
-else {
-    Write-Host "Failed to set shell for $Username using reg.exe." -ForegroundColor Red
+    Write-Host "Custom shell set to $shellValue for $env:USERNAME. Restart the computer to apply changes." -ForegroundColor Green
 }

--- a/set_custom_shell.ps1
+++ b/set_custom_shell.ps1
@@ -57,9 +57,10 @@ else {
     $hiveLoaded = $false
 }
 
+
 # Ensure Winlogon key exists
 if (-not (Test-Path $regPath)) {
-    New-Item -Path (Split-Path $regPath -Parent) -Name 'Winlogon' | Out-Null
+    New-Item -Path $regPath -Force | Out-Null
 }
 
 try {

--- a/set_custom_shell.ps1
+++ b/set_custom_shell.ps1
@@ -58,9 +58,13 @@ else {
 }
 
 
-# Ensure Winlogon key exists
+# Ensure each parent key exists for the Winlogon key
+$parentPath = "Registry::HKEY_USERS\$userSID\Software\Microsoft\Windows NT\CurrentVersion"
+if (-not (Test-Path $parentPath)) {
+    New-Item -Path "Registry::HKEY_USERS\$userSID\Software\Microsoft\Windows NT" -Name 'CurrentVersion' | Out-Null
+}
 if (-not (Test-Path $regPath)) {
-    New-Item -Path $regPath -Force | Out-Null
+    New-Item -Path $parentPath -Name 'Winlogon' | Out-Null
 }
 
 try {

--- a/set_custom_shell.ps1
+++ b/set_custom_shell.ps1
@@ -58,13 +58,24 @@ else {
 }
 
 
+
 # Ensure each parent key exists for the Winlogon key
 $parentPath = "Registry::HKEY_USERS\$userSID\Software\Microsoft\Windows NT\CurrentVersion"
 if (-not (Test-Path $parentPath)) {
-    New-Item -Path "Registry::HKEY_USERS\$userSID\Software\Microsoft\Windows NT" -Name 'CurrentVersion' | Out-Null
+    New-Item -Path "Registry::HKEY_USERS\$userSID\Software\Microsoft\Windows NT" -Name 'CurrentVersion' -Force | Out-Null
 }
 if (-not (Test-Path $regPath)) {
-    New-Item -Path $parentPath -Name 'Winlogon' | Out-Null
+    New-Item -Path $parentPath -Name 'Winlogon' -Force | Out-Null
+}
+
+# Double-check the key exists before setting the property
+if (-not (Test-Path $regPath)) {
+    Write-Host "Failed to create Winlogon registry key for $Username." -ForegroundColor Red
+    if ($hiveLoaded) {
+        reg unload HKU\$userSID | Out-Null
+        Write-Host "Unloaded registry hive for $Username." -ForegroundColor Yellow
+    }
+    exit 1
 }
 
 try {

--- a/set_custom_shell.ps1
+++ b/set_custom_shell.ps1
@@ -1,4 +1,4 @@
-# This script sets your custom shell (Menu.exe) as the default Windows shell for all users.
+# This script sets your custom shell (Menu.exe) as the default Windows shell for a specific user.
 # It also provides an option to restore the default shell (explorer.exe).
 # Run this script as Administrator.
 
@@ -25,26 +25,26 @@ if (-not $Username) {
     exit 1
 }
 
-
 $userSID = Get-UserSID -UserName $Username
 $regPath = "Registry::HKEY_USERS\\$userSID\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon"
-$shellValue = if ($Restore) { 'explorer.exe' } else { "C:\\Users\\$Username\\Documents\\Scripts\\Kiosk\\Menu.exe" }
+# Get user profile path for dynamic shell path
+$userProfile = (Get-CimInstance -ClassName Win32_UserProfile | Where-Object { $_.SID -eq $userSID }).LocalPath
+if (-not $userProfile) {
+    Write-Host "Could not find profile path for $Username (SID: $userSID)." -ForegroundColor Red
+    exit 1
+}
+$shellValue = if ($Restore) { 'explorer.exe' } else { "$userProfile\\Documents\\Scripts\\Kiosk\\Menu.exe" }
 
 # Check if the user's hive is loaded
 if (-not (Test-Path $regPath)) {
     # Try to load the user's hive
-    $userProfile = (Get-CimInstance -ClassName Win32_UserProfile | Where-Object { $_.SID -eq $userSID }).LocalPath
-    if (-not $userProfile) {
-        Write-Host "Could not find profile path for $Username (SID: $userSID)." -ForegroundColor Red
-        exit 1
-    }
     $ntuserDat = Join-Path $userProfile 'NTUSER.DAT'
     if (-not (Test-Path $ntuserDat)) {
         Write-Host "NTUSER.DAT not found at $ntuserDat. User profile may not exist or is not loaded." -ForegroundColor Red
         exit 1
     }
     try {
-        reg load "HKU\\$userSID" "$ntuserDat" | Out-Null
+        reg load HKU\$userSID "$ntuserDat" | Out-Null
         $hiveLoaded = $true
         Write-Host "Loaded registry hive for $Username." -ForegroundColor Yellow
     }
@@ -55,6 +55,11 @@ if (-not (Test-Path $regPath)) {
 }
 else {
     $hiveLoaded = $false
+}
+
+# Ensure Winlogon key exists
+if (-not (Test-Path $regPath)) {
+    New-Item -Path (Split-Path $regPath -Parent) -Name 'Winlogon' | Out-Null
 }
 
 try {
@@ -73,7 +78,7 @@ catch {
 # Unload the hive if we loaded it
 if ($hiveLoaded) {
     try {
-        reg unload "HKU\\$userSID" | Out-Null
+        reg unload HKU\$userSID | Out-Null
         Write-Host "Unloaded registry hive for $Username." -ForegroundColor Yellow
     }
     catch {

--- a/set_custom_shell.ps1
+++ b/set_custom_shell.ps1
@@ -108,4 +108,3 @@ catch {
     Write-Host "Failed to set shell for $Username. Try running as Administrator." -ForegroundColor Red
     Write-Host "[DEBUG] Set-ItemProperty error: $_" -ForegroundColor Red
 }
-}


### PR DESCRIPTION
This pull request simplifies and streamlines the `set_custom_shell.ps1` script by removing user-specific logic and improving the handling of registry modifications. The script now operates directly on the current user's registry hive without requiring a username parameter or manually loading/unloading registry hives.

### Simplifications and improvements to script logic:

* Removed the `Username` parameter and associated logic for resolving user SIDs and loading/unloading registry hives. The script now operates directly on the current user's registry hive (`HKCU`).
* Simplified the registry path handling by directly referencing `HKCU:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon` and ensuring the key exists using `New-Item`.
* Updated the shell value logic to use `$env:USERPROFILE` for setting the custom shell path, eliminating the need for user-specific paths.

### User experience enhancements:

* Updated output messages to use `$env:USERNAME` instead of the removed `Username` parameter, ensuring accurate feedback for the current user.
* Removed error handling related to user profile and registry hive loading, as these are no longer applicable with the simplified approach.

